### PR TITLE
Adjust transfer generation template to AbstractTransfer static properties

### DIFF
--- a/src/Spryker/Zed/Transfer/Business/Model/Generator/Templates/macros.php.twig
+++ b/src/Spryker/Zed/Transfer/Business/Model/Generator/Templates/macros.php.twig
@@ -14,7 +14,7 @@
     /**
      * @var array
      */
-    protected $transferMetadata = [
+    protected static $transferMetadata = [
     {% for property in normalizedProperties %}
     self::{{ property.propertyConst }} => [
             'type' => '{{ property.type_fully_qualified }}',
@@ -40,7 +40,7 @@
     /**
      * @var array
      */
-    protected $transferPropertyNameMap = [
+    protected static $transferPropertyNameMap = [
     {% for propertyNameUnderScore, propertyNameCamelCase  in propertyNameMap %}
     '{{ propertyNameUnderScore }}' => '{{ propertyNameCamelCase }}',
     {% endfor -%}


### PR DESCRIPTION
This is a complement to the PR https://github.com/spryker/kernel/pull/1 that makes the AbstractTransfer properties static. 