### PR TITLE
Add @throws PHPDoc annotation to require*() and get*OrFail() methods

### DIFF
--- a/src/Spryker/Zed/Transfer/Business/Model/Generator/Templates/macros.php.twig
+++ b/src/Spryker/Zed/Transfer/Business/Model/Generator/Templates/macros.php.twig
@@ -151,6 +151,8 @@
      * @deprecated {{ method.deprecationDescription }}
      *
      {% endif -%}
+     * @throws \Spryker\Shared\Kernel\Transfer\Exception\NullValueException
+     *
      * @return {{ method.return }}
      */
     public function {{ method.name }}(){% if method.returnTypeHint is defined %}: {{ method.returnTypeHint }}{% endif ~%}
@@ -254,6 +256,8 @@
      * @deprecated {{ method.deprecationDescription }}
      *
      {% endif -%}
+     * @throws \Spryker\Shared\Kernel\Transfer\Exception\RequiredTransferPropertyException
+     *
      * @return $this
      */
     public function {{ method.name }}()


### PR DESCRIPTION
## PR Description

The `require*()` methods call `$this->assertCollectionPropertyIsSet()` or `$this->assertPropertyIsSet()` which both can throw this exception and actually have this annotation set, so the `require*()` methods should have this annotation set too.

The same applies for the `get*OrFail()` methods, which call `$this->throwNullValueException()` which throws an exception, and also already has this annotation set.

With this change, it is easier for static code analysis tools and IDE implementations to report uncatched exceptions.

Additionally, [phpstan outlines](https://phpstan.org/blog/bring-your-exceptions-under-control) a difference between "checked" and "unchecked" exceptions, whereby they suggest that "checked" exceptions should have a `@throws` annotation, and the cases touched here are "checked" exceptions.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
