### PR TITLE
More strict return type for build() method in PHPDoc

### DIFF
--- a/src/Spryker/Zed/Transfer/Business/Model/Generator/Templates/builder.php.twig
+++ b/src/Spryker/Zed/Transfer/Business/Model/Generator/Templates/builder.php.twig
@@ -44,7 +44,7 @@ class {{ className }} extends AbstractDataBuilder
     ];
 
     /**
-     * @return \Generated\Shared\Transfer\{{ transferName }}|\Spryker\Shared\Kernel\Transfer\AbstractTransfer
+     * @return \Generated\Shared\Transfer\{{ transferName }}
      */
     public function build()
     {


### PR DESCRIPTION
## PR Description

This change seems logical, because getTransfer() method returns strict type:

```php
   /**
     * @return \Generated\Shared\Transfer\{{ transferName }}
     */
    public function getTransfer()
```

but build() for some reason returns mixed:

```php
   /**
     * @return \Generated\Shared\Transfer\{{ transferName }}|\Spryker\Shared\Kernel\Transfer\AbstractTransfer
     */
    public function build()
```

It causes errors of PHPStan tool for example which checks if we pass the object of exact type like those:

```
Parameter #1 $brandTransfer of method Pyz\Zed\Brand\Business\BrandFacadeInterface::createBrand() expects Generated\Shared\Transfer\BrandTransfer,
         Spryker\Shared\Kernel\Transfer\AbstractTransfer given
```

In this context createBrand can't resolve return type of the build() method and thus can't be used 

TBD

## Checklist
- [ ] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
