### PR TITLE
Fix intersection type syntax for collections

### DIFF
--- a/src/Spryker/Zed/Transfer/Business/Model/Generator/ClassDefinition.php
+++ b/src/Spryker/Zed/Transfer/Business/Model/Generator/ClassDefinition.php
@@ -395,7 +395,9 @@ class ClassDefinition implements ClassDefinitionInterface
         }
 
         if ($this->isCollection($property)) {
-            return '\ArrayObject|\Generated\Shared\Transfer\\' . $property['type'];
+            $type = preg_replace('/\[\]/', '', $property['type']);
+
+            return "\ArrayObject|array<$type>";
         }
 
         if ($this->isTypeTransferObject($property)) {
@@ -445,7 +447,9 @@ class ClassDefinition implements ClassDefinitionInterface
         }
 
         if ($this->isCollection($property)) {
-            return '\ArrayObject|\Generated\Shared\Transfer\\' . $property['type'];
+            $type = preg_replace('/\[\]/', '', $property['type']);
+
+            return "\ArrayObject|array<$type>";
         }
 
         if ($this->isTypeTransferObject($property)) {
@@ -673,7 +677,9 @@ class ClassDefinition implements ClassDefinitionInterface
         }
 
         if ($this->isCollection($property)) {
-            return '\\ArrayObject|\Generated\Shared\Transfer\\' . $property['type'];
+            $type = preg_replace('/\[\]/', '', $property['type']);
+
+            return "\ArrayObject|array<$type>";
         }
 
         if ($this->isTypeTransferObject($property)) {

--- a/src/Spryker/Zed/Transfer/Business/Model/Generator/Templates/macros.php.twig
+++ b/src/Spryker/Zed/Transfer/Business/Model/Generator/Templates/macros.php.twig
@@ -39,7 +39,7 @@
 {# property #}
 {% macro addProperty(property) %}
     /**
-     * @var {{ property.type }}
+     * @var {{ property.type|raw }}
      */
     protected ${{ property.name }}{% if property.is_array_collection %} = []{% endif %};
 {% endmacro %}
@@ -81,7 +81,7 @@
      * @deprecated {{ method.deprecationDescription }}
      *
      {% endif -%}
-     * @param {{ method.var }}{% if method.hasDefaultNull %}|null{% endif %} ${{ method.property }}{% if method.typeShimNotice %} {{ method.typeShimNotice }}{% endif ~%}
+     * @param {{ method.var|raw }}{% if method.hasDefaultNull %}|null{% endif %} ${{ method.property }}{% if method.typeShimNotice %} {{ method.typeShimNotice }}{% endif ~%}
      *
      * @return $this
      */
@@ -136,7 +136,7 @@
      * @deprecated {{ method.deprecationDescription }}
      *
      {% endif -%}
-     * @return {{ method.return }}{% if method.typeShimNotice %} {{ method.typeShimNotice }}{% endif ~%}
+     * @return {{ method.return|raw }}{% if method.typeShimNotice %} {{ method.typeShimNotice }}{% endif ~%}
      */
     public function {{ method.name }}(){% if method.returnTypeHint is defined %}: {{ method.returnTypeHint }}{% endif ~%}
     {
@@ -157,7 +157,7 @@
      * @deprecated {{ method.deprecationDescription }}
      *
      {% endif -%}
-     * @return {{ method.return }}
+     * @return {{ method.return|raw }}
      */
     public function {{ method.name }}(){% if method.returnTypeHint is defined %}: {{ method.returnTypeHint }}{% endif ~%}
     {


### PR DESCRIPTION
## PR Description

This will change collection types to the union type syntax, by explicitly using the `array<Type>` syntax instead of `Type[]` in parameters, setters, and getters.

See also this example from [the PHPStan documentation](https://phpstan.org/blog/union-types-vs-intersection-types):
![image](https://user-images.githubusercontent.com/1001186/153210164-778abd20-f545-4f1f-9c31-f33356f92cf2.png)

Consider these two examples:
* https://phpstan.org/r/1341f0dc-50a4-4432-b100-9d05f3d918be
* https://phpstan.org/r/26a661c4-0f4e-493a-bdb9-839271f9a822

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
