### PR TITLE
Replace docblock with typed class constants

### DIFF
--- a/templates/generator/macros.php.twig
+++ b/templates/generator/macros.php.twig
@@ -4,12 +4,8 @@
     /**
      * @deprecated {{ constant.deprecationDescription }}
      */
-    {% else -%}
-    /**
-     * @var string
-     */
     {% endif -%}
-    public const {{ constant.name }} = '{{ constant.value }}';
+    public const string {{ constant.name }} = '{{ constant.value }}';
 
 {% endmacro %}
 


### PR DESCRIPTION
## PR Description
Replaced docblock type annotation for constants in favor of [typed class constants](https://www.php.net/releases/8.3/en.php#typed_class_constants).

Strong guarantee of type and a minor disk space utilization improvement.

## Steps before you submit a PR
- Please add tests for the code you add if it's possible.
- Please check out our contribution guide: https://docs.spryker.com/docs/dg/dev/code-contribution-guide.html
- Add a `contribution-license-agreement.txt` file with the following content:
`I hereby agree to Spryker\'s Contribution License Agreement in https://github.com/spryker/.github/blob/HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH/CONTRIBUTING.md.`

This is a mandatory step to make sure you are aware of the license agreement and agree to it. `HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH` is a hash of the commit you are basing your branch from the master branch. You can take it from commits list of master branch before you submit a PR.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
